### PR TITLE
Scalar function coverage

### DIFF
--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -1,5 +1,10 @@
-add_subdirectory(scalar)
+add_library(
+        functions
+        OBJECT
+        query_library_version.c
+        query_scalar_functions.c
+)
 
 set(ALL_OBJECT_FILES
-    ${ALL_OBJECT_FILES}
-    PARENT_SCOPE)
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:functions>
+        PARENT_SCOPE)

--- a/src/functions/query_library_version.c
+++ b/src/functions/query_library_version.c
@@ -6,15 +6,14 @@ static void LibraryVersionFunction(duckdb_function_info info, duckdb_data_chunk 
 	const char *version = duckdb_library_version();
 
 	idx_t input_size = duckdb_data_chunk_get_size(input);
-
 	for (idx_t row = 0; row < input_size; row++) {
 		duckdb_vector_assign_string_element(output, row, version);
 	}
 }
 
-void RegisterLibraryVersionFunction(duckdb_connection connection) {
+duckdb_state RegisterLibraryVersionFunction(duckdb_connection connection) {
 	duckdb_scalar_function function = duckdb_create_scalar_function();
-	duckdb_scalar_function_set_name(function, "capi_test_duckdb_library_version");
+	duckdb_scalar_function_set_name(function, "capi_duckdb_library_version");
 
 	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
 	duckdb_scalar_function_set_return_type(function, type);
@@ -22,6 +21,7 @@ void RegisterLibraryVersionFunction(duckdb_connection connection) {
 
 	duckdb_scalar_function_set_function(function, LibraryVersionFunction);
 
-	duckdb_register_scalar_function(connection, function);
+	duckdb_state state = duckdb_register_scalar_function(connection, function);
 	duckdb_destroy_scalar_function(&function);
+    return state;
 }

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -16,41 +16,13 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
     duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
 	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
 
-
-//    // NOTE: For simplicity, we assume there are no NULL values.
-//    // See CountNULL for NULL value handling.
+    // NOTE: For simplicity, we assume there are no NULL values.
+    // See CountNULL for NULL value handling.
     for (idx_t row = 0; row < input_size; row++) {
         duckdb_string_t data = input_data[row];
-//
-////        // Determine the result string length.
-////        idx_t result_len = extra_info_len;
         bool is_inlined = duckdb_string_is_inlined(data);
         idx_t truncate = is_inlined ? 1 : 6;
         duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - truncate * sizeof(char));
-
-
-////        if (is_inlined) {
-////            result_len += input_char.value.inlined.length;
-////        } else {
-////            result_len += input_char.value.pointer.length;
-////        }
-////
-////        // Create the result string.
-////if (is_inlined) {
-////    char *result = (char *)malloc(result_len * sizeof(char));
-////    free(result);
-////}
-//
-////        strcpy(result, extra_info);
-////        if (is_inlined) {
-////            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
-////        } else {
-////            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
-////        }
-////
-////        // Assign and free.
-//        duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - 1 * sizeof(char));
-//
     }
 }
 

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -7,7 +7,7 @@ DUCKDB_EXTENSION_EXTERN
 // FIXME: strcpy causes a warning on Windows. C99 does not have strcpy_s.
 
 void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
+//    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
     idx_t extra_info_len = 7;
 
     // Set up input.
@@ -20,27 +20,31 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
     for (idx_t row = 0; row < input_size; row++) {
         duckdb_string_t input_char = input_data[row];
 
-        // Determine the result string length.
+//        // Determine the result string length.
         idx_t result_len = extra_info_len;
         bool is_inlined = duckdb_string_is_inlined(input_char);
-        if (is_inlined) {
-            result_len += input_char.value.inlined.length;
-        } else {
-            result_len += input_char.value.pointer.length;
-        }
+//        if (is_inlined) {
+//            result_len += input_char.value.inlined.length;
+//        } else {
+//            result_len += input_char.value.pointer.length;
+//        }
+//
+//        // Create the result string.
+if (is_inlined) {
+    char *result = (char *)malloc(result_len * sizeof(char));
+    free(result);
+}
 
-        // Create the result string.
-        char *result = (char *)malloc(result_len);
-        strcpy(result, extra_info);
-        if (is_inlined) {
-            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
-        } else {
-            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
-        }
+//        strcpy(result, extra_info);
+//        if (is_inlined) {
+//            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
+//        } else {
+//            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
+//        }
+//
+//        // Assign and free.
+//        duckdb_vector_assign_string_element_len(output, row, result, result_len);
 
-        // Assign and free.
-        duckdb_vector_assign_string_element_len(output, row, result, result_len);
-        free(result);
     }
 }
 

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -69,6 +69,11 @@ void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb
     idx_t column_count = duckdb_data_chunk_get_column_count(input);
 
     int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
+    if (data_ptrs == NULL) {
+        duckdb_function_set_error(info, "data_ptrs does not work");
+        return;
+    }
+
     for (idx_t i = 0; i < column_count; i++) {
         duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
         data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
@@ -130,6 +135,11 @@ void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector
 
     // Extract the validity masks.
     uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
+    if (validity_masks == NULL) {
+        duckdb_function_set_error(info, "validity_masks does not work");
+        return;
+    }
+
     for (idx_t i = 0; i < column_count; i++) {
         duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
         validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -109,20 +109,19 @@ duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection conne
 }
 
 duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection) {
-    return DuckDBSuccess;
-//    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
-//
-//    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
-//    duckdb_add_scalar_function_to_set(function_set, function);
-//    duckdb_destroy_scalar_function(&function);
-//
-//    function = GetVariadicAdditionScalarFunction(connection, "capi_add_three_scalar_function", 3);
-//    duckdb_add_scalar_function_to_set(function_set, function);
-//    duckdb_destroy_scalar_function(&function);
-//
-//    duckdb_state state = duckdb_register_scalar_function_set(connection, function_set);
-//    duckdb_destroy_scalar_function_set(&function_set);
-//    return state;
+    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
+
+    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
+    duckdb_add_scalar_function_to_set(function_set, function);
+    duckdb_destroy_scalar_function(&function);
+
+    function = GetVariadicAdditionScalarFunction(connection, "capi_add_three_scalar_function", 3);
+    duckdb_add_scalar_function_to_set(function_set, function);
+    duckdb_destroy_scalar_function(&function);
+
+    duckdb_state state = duckdb_register_scalar_function_set(connection, function_set);
+    duckdb_destroy_scalar_function_set(&function_set);
+    return state;
 }
 
 void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -1,0 +1,167 @@
+#include "duckdb_extension.h"
+#include <stdlib.h>
+#include <string.h>
+
+DUCKDB_EXTENSION_EXTERN
+
+void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
+    idx_t extra_info_len = 7;
+
+    // Set up input.
+    idx_t input_size = duckdb_data_chunk_get_size(input);
+    duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
+	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
+
+    // NOTE: For simplicity, we assume there are no NULL values.
+    // See CountNULL for NULL value handling.
+	for (idx_t row = 0; row < input_size; row++) {
+        duckdb_string_t input_char = input_data[row];
+
+        // Determine the result string length.
+        idx_t result_len = extra_info_len;
+        bool is_inlined = duckdb_string_is_inlined(input_char);
+        if (is_inlined) {
+            result_len += input_char.value.inlined.length;
+        } else {
+            result_len += input_char.value.pointer.length;
+        }
+
+        // Create the result string.
+        char *result = (char *)malloc(result_len);
+        strcpy(result, extra_info);
+        if (is_inlined) {
+            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
+        } else {
+            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
+        }
+
+        // Assign and free.
+        duckdb_vector_assign_string_element_len(output, row, result, result_len);
+        free(result);
+	}
+}
+
+duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
+    duckdb_scalar_function function = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
+
+    char *prefix = (char *)malloc(8);
+	strcpy(prefix, "prefix_");
+
+	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	duckdb_scalar_function_add_parameter(function, type);
+	duckdb_scalar_function_set_return_type(function, type);
+	duckdb_destroy_logical_type(&type);
+
+	duckdb_scalar_function_set_function(function, AppendToPrefix);
+	duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
+
+    duckdb_state state = duckdb_register_scalar_function(connection, function);
+	duckdb_destroy_scalar_function(&function);
+    return state;
+}
+
+void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+    idx_t input_size = duckdb_data_chunk_get_size(input);
+    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+
+    int64_t *data_ptrs[column_count];
+    for (idx_t i = 0; i < column_count; i++) {
+        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+        data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
+    }
+
+    // NOTE: For simplicity, we assume there are no NULL values.
+    // See CountNULL for NULL value handling.
+    int64_t *result_data = (int64_t *)duckdb_vector_get_data(output);
+    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+        result_data[row_idx] = 0;
+        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+            int64_t data = data_ptrs[col_idx][row_idx];
+            result_data[row_idx] += data;
+        }
+    }
+}
+
+duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection connection, const char *name, idx_t parameter_count) {
+    duckdb_scalar_function function = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(function, name);
+
+    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    for (idx_t idx = 0; idx < parameter_count; idx++) {
+        duckdb_scalar_function_add_parameter(function, type);
+    }
+    duckdb_scalar_function_set_return_type(function, type);
+    duckdb_destroy_logical_type(&type);
+
+    duckdb_scalar_function_set_function(function, VariadicAddition);
+    return function;
+}
+
+duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection) {
+    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
+
+    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
+    duckdb_add_scalar_function_to_set(function_set, function);
+    duckdb_destroy_scalar_function(&function);
+
+    function = GetVariadicAdditionScalarFunction(connection, "capi_add_three_scalar_function", 3);
+    duckdb_add_scalar_function_to_set(function_set, function);
+    duckdb_destroy_scalar_function(&function);
+
+    duckdb_state state = duckdb_register_scalar_function_set(connection, function_set);
+    duckdb_destroy_scalar_function_set(&function_set);
+    return state;
+}
+
+void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+    idx_t input_size = duckdb_data_chunk_get_size(input);
+    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+
+    // Extra shenanigans to test duckdb_scalar_function_set_error.
+    if (column_count == 0) {
+        duckdb_scalar_function_set_error(info, "please provide at least one input parameter");
+        return;
+    }
+
+    // Extract the validity masks.
+    uint64_t *validity_masks[column_count];
+    for (idx_t i = 0; i < column_count; i++) {
+        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+        validity_masks[i] = duckdb_vector_get_validity(col);
+    }
+
+    uint64_t *result_data = duckdb_vector_get_data(output);
+    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+        idx_t null_count = 0;
+        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+            if (!duckdb_validity_row_is_valid(validity_masks[col_idx], row_idx)) {
+                null_count++;
+            }
+        }
+        result_data[row_idx] = null_count;
+    }
+}
+
+duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection) {
+    duckdb_scalar_function function = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
+
+    duckdb_logical_type any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
+    duckdb_scalar_function_set_varargs(function, any_type);
+    duckdb_destroy_logical_type(&any_type);
+
+    duckdb_scalar_function_set_special_handling(function);
+    duckdb_scalar_function_set_volatile(function);
+
+    duckdb_logical_type return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
+    duckdb_scalar_function_set_return_type(function, return_type);
+    duckdb_destroy_logical_type(&return_type);
+
+    duckdb_scalar_function_set_function(function, CountNULL);
+
+    duckdb_state state = duckdb_register_scalar_function(connection, function);
+    duckdb_destroy_scalar_function(&function);
+    return state;
+}

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -65,31 +65,31 @@ duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
 }
 
 void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-    idx_t input_size = duckdb_data_chunk_get_size(input);
-    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+//    idx_t input_size = duckdb_data_chunk_get_size(input);
+//    idx_t column_count = duckdb_data_chunk_get_column_count(input);
 
-    int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
-    if (data_ptrs == NULL) {
-        duckdb_function_set_error(info, "data_ptrs does not work");
-        return;
-    }
+//    int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
+//    if (data_ptrs == NULL) {
+//        duckdb_function_set_error(info, "data_ptrs does not work");
+//        return;
+//    }
 
-    for (idx_t i = 0; i < column_count; i++) {
-        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
-        data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
-    }
-
-    // NOTE: For simplicity, we assume there are no NULL values.
-    // See CountNULL for NULL value handling.
-    int64_t *result_data = (int64_t *)duckdb_vector_get_data(output);
-    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
-        result_data[row_idx] = 0;
-        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-            int64_t data = data_ptrs[col_idx][row_idx];
-            result_data[row_idx] += data;
-        }
-    }
-    free(data_ptrs);
+//    for (idx_t i = 0; i < column_count; i++) {
+//        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+//        data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
+//    }
+//
+//    // NOTE: For simplicity, we assume there are no NULL values.
+//    // See CountNULL for NULL value handling.
+//    int64_t *result_data = (int64_t *)duckdb_vector_get_data(output);
+//    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+//        result_data[row_idx] = 0;
+//        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+//            int64_t data = data_ptrs[col_idx][row_idx];
+//            result_data[row_idx] += data;
+//        }
+//    }
+//    free(data_ptrs);
 }
 
 duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection connection, const char *name, idx_t parameter_count) {
@@ -124,38 +124,38 @@ duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection) {
 }
 
 void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-    idx_t input_size = duckdb_data_chunk_get_size(input);
-    idx_t column_count = duckdb_data_chunk_get_column_count(input);
-
-    // Extra shenanigans to test duckdb_scalar_function_set_error.
-    if (column_count == 0) {
-        duckdb_scalar_function_set_error(info, "please provide at least one input parameter");
-        return;
-    }
-
-    // Extract the validity masks.
-    uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
-    if (validity_masks == NULL) {
-        duckdb_function_set_error(info, "validity_masks does not work");
-        return;
-    }
-
-    for (idx_t i = 0; i < column_count; i++) {
-        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
-        validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);
-    }
-
-    uint64_t *result_data = duckdb_vector_get_data(output);
-    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
-        idx_t null_count = 0;
-        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-            if (!duckdb_validity_row_is_valid(validity_masks[col_idx], row_idx)) {
-                null_count++;
-            }
-        }
-        result_data[row_idx] = null_count;
-    }
-    free(validity_masks);
+//    idx_t input_size = duckdb_data_chunk_get_size(input);
+//    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+//
+//    // Extra shenanigans to test duckdb_scalar_function_set_error.
+//    if (column_count == 0) {
+//        duckdb_scalar_function_set_error(info, "please provide at least one input parameter");
+//        return;
+//    }
+//
+//    // Extract the validity masks.
+//    uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
+//    if (validity_masks == NULL) {
+//        duckdb_function_set_error(info, "validity_masks does not work");
+//        return;
+//    }
+//
+//    for (idx_t i = 0; i < column_count; i++) {
+//        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+//        validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);
+//    }
+//
+//    uint64_t *result_data = duckdb_vector_get_data(output);
+//    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+//        idx_t null_count = 0;
+//        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+//            if (!duckdb_validity_row_is_valid(validity_masks[col_idx], row_idx)) {
+//                null_count++;
+//            }
+//        }
+//        result_data[row_idx] = null_count;
+//    }
+//    free(validity_masks);
 }
 
 duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection) {

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -8,7 +8,7 @@ DUCKDB_EXTENSION_EXTERN
 
 void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
 //    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
-    idx_t extra_info_len = 7;
+//    idx_t extra_info_len = 7;
 
     // Set up input.
     idx_t input_size = duckdb_data_chunk_get_size(input);
@@ -17,12 +17,16 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 
     // NOTE: For simplicity, we assume there are no NULL values.
     // See CountNULL for NULL value handling.
+    idx_t count = 0;
     for (idx_t row = 0; row < input_size; row++) {
         duckdb_string_t input_char = input_data[row];
 
 //        // Determine the result string length.
-        idx_t result_len = extra_info_len;
+//        idx_t result_len = extra_info_len;
         bool is_inlined = duckdb_string_is_inlined(input_char);
+        if (is_inlined) {
+            count++;
+        }
 //        if (is_inlined) {
 //            result_len += input_char.value.inlined.length;
 //        } else {
@@ -30,10 +34,10 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 //        }
 //
 //        // Create the result string.
-if (is_inlined) {
-    char *result = (char *)malloc(result_len * sizeof(char));
-    free(result);
-}
+//if (is_inlined) {
+//    char *result = (char *)malloc(result_len * sizeof(char));
+//    free(result);
+//}
 
 //        strcpy(result, extra_info);
 //        if (is_inlined) {

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -7,48 +7,44 @@ DUCKDB_EXTENSION_EXTERN
 // FIXME: strcpy causes a warning on Windows. C99 does not have strcpy_s.
 
 void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-//    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
-//    idx_t extra_info_len = 7;
+    const char *extra_info = (const char *)duckdb_scalar_function_get_extra_info(info);
+    idx_t extra_info_len = 11 * sizeof(char);
 
     // Set up input.
     idx_t input_size = duckdb_data_chunk_get_size(input);
-    duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
-	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
+//    duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
+//	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
 
-    // NOTE: For simplicity, we assume there are no NULL values.
-    // See CountNULL for NULL value handling.
-    idx_t count = 0;
+//    // NOTE: For simplicity, we assume there are no NULL values.
+//    // See CountNULL for NULL value handling.
     for (idx_t row = 0; row < input_size; row++) {
-        duckdb_string_t input_char = input_data[row];
-
-//        // Determine the result string length.
-//        idx_t result_len = extra_info_len;
-        bool is_inlined = duckdb_string_is_inlined(input_char);
-        if (is_inlined) {
-            count++;
-        }
-//        if (is_inlined) {
-//            result_len += input_char.value.inlined.length;
-//        } else {
-//            result_len += input_char.value.pointer.length;
-//        }
+//        duckdb_string_t input_char = input_data[row];
 //
-//        // Create the result string.
-//if (is_inlined) {
-//    char *result = (char *)malloc(result_len * sizeof(char));
-//    free(result);
-//}
-
-//        strcpy(result, extra_info);
-//        if (is_inlined) {
-//            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
-//        } else {
-//            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
-//        }
+////        // Determine the result string length.
+////        idx_t result_len = extra_info_len;
+////        bool is_inlined = duckdb_string_is_inlined(input_char);
+////        if (is_inlined) {
+////            result_len += input_char.value.inlined.length;
+////        } else {
+////            result_len += input_char.value.pointer.length;
+////        }
+////
+////        // Create the result string.
+////if (is_inlined) {
+////    char *result = (char *)malloc(result_len * sizeof(char));
+////    free(result);
+////}
 //
-//        // Assign and free.
-//        duckdb_vector_assign_string_element_len(output, row, result, result_len);
-
+////        strcpy(result, extra_info);
+////        if (is_inlined) {
+////            strcpy(result + extra_info_len, input_char.value.inlined.inlined);
+////        } else {
+////            strcpy(result + extra_info_len, input_char.value.pointer.ptr);
+////        }
+////
+////        // Assign and free.
+        duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - 1 * sizeof(char));
+//
     }
 }
 
@@ -56,8 +52,8 @@ duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
     duckdb_scalar_function function = duckdb_create_scalar_function();
     duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
 
-    char *prefix = (char *)malloc(8 * sizeof(char));
-    strcpy(prefix, "prefix_");
+    char *prefix = (char *)malloc(11 * sizeof(char));
+    strcpy(prefix, "extra_info");
 
     duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
     duckdb_scalar_function_add_parameter(function, type);

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -45,51 +45,52 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 }
 
 duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
-    duckdb_scalar_function function = duckdb_create_scalar_function();
-    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
-
-    char *prefix = (char *)malloc(8 * sizeof(char));
-    strcpy(prefix, "prefix_");
-
-    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-    duckdb_scalar_function_add_parameter(function, type);
-    duckdb_scalar_function_set_return_type(function, type);
-    duckdb_destroy_logical_type(&type);
-
-    duckdb_scalar_function_set_function(function, AppendToPrefix);
-    duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
-
-    duckdb_state state = duckdb_register_scalar_function(connection, function);
-    duckdb_destroy_scalar_function(&function);
-    return state;
+    return;
+//    duckdb_scalar_function function = duckdb_create_scalar_function();
+//    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
+//
+//    char *prefix = (char *)malloc(8 * sizeof(char));
+//    strcpy(prefix, "prefix_");
+//
+//    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+//    duckdb_scalar_function_add_parameter(function, type);
+//    duckdb_scalar_function_set_return_type(function, type);
+//    duckdb_destroy_logical_type(&type);
+//
+//    duckdb_scalar_function_set_function(function, AppendToPrefix);
+//    duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
+//
+//    duckdb_state state = duckdb_register_scalar_function(connection, function);
+//    duckdb_destroy_scalar_function(&function);
+//    return state;
 }
 
 void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-//    idx_t input_size = duckdb_data_chunk_get_size(input);
-//    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+    idx_t input_size = duckdb_data_chunk_get_size(input);
+    idx_t column_count = duckdb_data_chunk_get_column_count(input);
 
-//    int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
-//    if (data_ptrs == NULL) {
-//        duckdb_function_set_error(info, "data_ptrs does not work");
-//        return;
-//    }
+    int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
+    if (data_ptrs == NULL) {
+        duckdb_function_set_error(info, "data_ptrs does not work");
+        return;
+    }
 
-//    for (idx_t i = 0; i < column_count; i++) {
-//        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
-//        data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
-//    }
-//
-//    // NOTE: For simplicity, we assume there are no NULL values.
-//    // See CountNULL for NULL value handling.
-//    int64_t *result_data = (int64_t *)duckdb_vector_get_data(output);
-//    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
-//        result_data[row_idx] = 0;
-//        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-//            int64_t data = data_ptrs[col_idx][row_idx];
-//            result_data[row_idx] += data;
-//        }
-//    }
-//    free(data_ptrs);
+    for (idx_t i = 0; i < column_count; i++) {
+        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+        data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
+    }
+
+    // NOTE: For simplicity, we assume there are no NULL values.
+    // See CountNULL for NULL value handling.
+    int64_t *result_data = (int64_t *)duckdb_vector_get_data(output);
+    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+        result_data[row_idx] = 0;
+        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+            int64_t data = data_ptrs[col_idx][row_idx];
+            result_data[row_idx] += data;
+        }
+    }
+    free(data_ptrs);
 }
 
 duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection connection, const char *name, idx_t parameter_count) {
@@ -108,74 +109,76 @@ duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection conne
 }
 
 duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection) {
-    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
-
-    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
-    duckdb_add_scalar_function_to_set(function_set, function);
-    duckdb_destroy_scalar_function(&function);
-
-    function = GetVariadicAdditionScalarFunction(connection, "capi_add_three_scalar_function", 3);
-    duckdb_add_scalar_function_to_set(function_set, function);
-    duckdb_destroy_scalar_function(&function);
-
-    duckdb_state state = duckdb_register_scalar_function_set(connection, function_set);
-    duckdb_destroy_scalar_function_set(&function_set);
-    return state;
+    return;
+//    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
+//
+//    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
+//    duckdb_add_scalar_function_to_set(function_set, function);
+//    duckdb_destroy_scalar_function(&function);
+//
+//    function = GetVariadicAdditionScalarFunction(connection, "capi_add_three_scalar_function", 3);
+//    duckdb_add_scalar_function_to_set(function_set, function);
+//    duckdb_destroy_scalar_function(&function);
+//
+//    duckdb_state state = duckdb_register_scalar_function_set(connection, function_set);
+//    duckdb_destroy_scalar_function_set(&function_set);
+//    return state;
 }
 
 void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-//    idx_t input_size = duckdb_data_chunk_get_size(input);
-//    idx_t column_count = duckdb_data_chunk_get_column_count(input);
-//
-//    // Extra shenanigans to test duckdb_scalar_function_set_error.
-//    if (column_count == 0) {
-//        duckdb_scalar_function_set_error(info, "please provide at least one input parameter");
-//        return;
-//    }
-//
-//    // Extract the validity masks.
-//    uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
-//    if (validity_masks == NULL) {
-//        duckdb_function_set_error(info, "validity_masks does not work");
-//        return;
-//    }
-//
-//    for (idx_t i = 0; i < column_count; i++) {
-//        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
-//        validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);
-//    }
-//
-//    uint64_t *result_data = duckdb_vector_get_data(output);
-//    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
-//        idx_t null_count = 0;
-//        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
-//            if (!duckdb_validity_row_is_valid(validity_masks[col_idx], row_idx)) {
-//                null_count++;
-//            }
-//        }
-//        result_data[row_idx] = null_count;
-//    }
-//    free(validity_masks);
+    idx_t input_size = duckdb_data_chunk_get_size(input);
+    idx_t column_count = duckdb_data_chunk_get_column_count(input);
+
+    // Extra shenanigans to test duckdb_scalar_function_set_error.
+    if (column_count == 0) {
+        duckdb_scalar_function_set_error(info, "please provide at least one input parameter");
+        return;
+    }
+
+    // Extract the validity masks.
+    uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
+    if (validity_masks == NULL) {
+        duckdb_function_set_error(info, "validity_masks does not work");
+        return;
+    }
+
+    for (idx_t i = 0; i < column_count; i++) {
+        duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
+        validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);
+    }
+
+    uint64_t *result_data = duckdb_vector_get_data(output);
+    for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+        idx_t null_count = 0;
+        for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+            if (!duckdb_validity_row_is_valid(validity_masks[col_idx], row_idx)) {
+                null_count++;
+            }
+        }
+        result_data[row_idx] = null_count;
+    }
+    free(validity_masks);
 }
 
 duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection) {
-    duckdb_scalar_function function = duckdb_create_scalar_function();
-    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
-
-    duckdb_logical_type any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
-    duckdb_scalar_function_set_varargs(function, any_type);
-    duckdb_destroy_logical_type(&any_type);
-
-    duckdb_scalar_function_set_special_handling(function);
-    duckdb_scalar_function_set_volatile(function);
-
-    duckdb_logical_type return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
-    duckdb_scalar_function_set_return_type(function, return_type);
-    duckdb_destroy_logical_type(&return_type);
-
-    duckdb_scalar_function_set_function(function, CountNULL);
-
-    duckdb_state state = duckdb_register_scalar_function(connection, function);
-    duckdb_destroy_scalar_function(&function);
-    return state;
+    return;
+//    duckdb_scalar_function function = duckdb_create_scalar_function();
+//    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
+//
+//    duckdb_logical_type any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
+//    duckdb_scalar_function_set_varargs(function, any_type);
+//    duckdb_destroy_logical_type(&any_type);
+//
+//    duckdb_scalar_function_set_special_handling(function);
+//    duckdb_scalar_function_set_volatile(function);
+//
+//    duckdb_logical_type return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
+//    duckdb_scalar_function_set_return_type(function, return_type);
+//    duckdb_destroy_logical_type(&return_type);
+//
+//    duckdb_scalar_function_set_function(function, CountNULL);
+//
+//    duckdb_state state = duckdb_register_scalar_function(connection, function);
+//    duckdb_destroy_scalar_function(&function);
+//    return state;
 }

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -68,7 +68,7 @@ void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb
     idx_t input_size = duckdb_data_chunk_get_size(input);
     idx_t column_count = duckdb_data_chunk_get_column_count(input);
 
-    int64_t **data_ptrs = malloc(column_count * sizeof(int64_t *));
+    int64_t **data_ptrs = (int64_t **)malloc(column_count * sizeof(int64_t *));
     for (idx_t i = 0; i < column_count; i++) {
         duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
         data_ptrs[i] = (int64_t *)duckdb_vector_get_data(col);
@@ -129,10 +129,10 @@ void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector
     }
 
     // Extract the validity masks.
-    uint64_t **validity_masks = malloc(column_count * sizeof(uint64_t *));
+    uint64_t **validity_masks = (uint64_t **)malloc(column_count * sizeof(uint64_t *));
     for (idx_t i = 0; i < column_count; i++) {
         duckdb_vector col = duckdb_data_chunk_get_vector(input, i);
-        validity_masks[i] = duckdb_vector_get_validity(col);
+        validity_masks[i] = (uint64_t *)duckdb_vector_get_validity(col);
     }
 
     uint64_t *result_data = duckdb_vector_get_data(output);

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -45,7 +45,7 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 }
 
 duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
-    return;
+    return DuckDBSuccess;
 //    duckdb_scalar_function function = duckdb_create_scalar_function();
 //    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
 //
@@ -109,7 +109,7 @@ duckdb_scalar_function GetVariadicAdditionScalarFunction(duckdb_connection conne
 }
 
 duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection) {
-    return;
+    return DuckDBSuccess;
 //    duckdb_scalar_function_set function_set = duckdb_create_scalar_function_set("variadic_addition_set");
 //
 //    duckdb_scalar_function function = GetVariadicAdditionScalarFunction(connection, "capi_add_two_scalar_function", 2);
@@ -161,7 +161,7 @@ void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector
 }
 
 duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection) {
-    return;
+    return DuckDBSuccess;
 //    duckdb_scalar_function function = duckdb_create_scalar_function();
 //    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
 //

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -1,6 +1,7 @@
 #include "duckdb_extension.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 DUCKDB_EXTENSION_EXTERN
 
@@ -12,17 +13,22 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 
     // Set up input.
     idx_t input_size = duckdb_data_chunk_get_size(input);
-//    duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
-//	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
+    duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
+	duckdb_string_t *input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
+
 
 //    // NOTE: For simplicity, we assume there are no NULL values.
 //    // See CountNULL for NULL value handling.
     for (idx_t row = 0; row < input_size; row++) {
-//        duckdb_string_t input_char = input_data[row];
+        duckdb_string_t data = input_data[row];
 //
 ////        // Determine the result string length.
 ////        idx_t result_len = extra_info_len;
-////        bool is_inlined = duckdb_string_is_inlined(input_char);
+        bool is_inlined = duckdb_string_is_inlined(data);
+        idx_t truncate = is_inlined ? 1 : 6;
+        duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - truncate * sizeof(char));
+
+
 ////        if (is_inlined) {
 ////            result_len += input_char.value.inlined.length;
 ////        } else {
@@ -43,7 +49,7 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 ////        }
 ////
 ////        // Assign and free.
-        duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - 1 * sizeof(char));
+//        duckdb_vector_assign_string_element_len(output, row, extra_info, extra_info_len - 1 * sizeof(char));
 //
     }
 }

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -15,7 +15,7 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 
     // NOTE: For simplicity, we assume there are no NULL values.
     // See CountNULL for NULL value handling.
-	for (idx_t row = 0; row < input_size; row++) {
+    for (idx_t row = 0; row < input_size; row++) {
         duckdb_string_t input_char = input_data[row];
 
         // Determine the result string length.
@@ -39,7 +39,7 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
         // Assign and free.
         duckdb_vector_assign_string_element_len(output, row, result, result_len);
         free(result);
-	}
+    }
 }
 
 duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
@@ -47,18 +47,18 @@ duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
     duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
 
     char *prefix = (char *)malloc(8);
-	strcpy(prefix, "prefix_");
+    strcpy(prefix, "prefix_");
 
-	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-	duckdb_scalar_function_add_parameter(function, type);
-	duckdb_scalar_function_set_return_type(function, type);
-	duckdb_destroy_logical_type(&type);
+    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    duckdb_scalar_function_add_parameter(function, type);
+    duckdb_scalar_function_set_return_type(function, type);
+    duckdb_destroy_logical_type(&type);
 
-	duckdb_scalar_function_set_function(function, AppendToPrefix);
-	duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
+    duckdb_scalar_function_set_function(function, AppendToPrefix);
+    duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
 
     duckdb_state state = duckdb_register_scalar_function(connection, function);
-	duckdb_destroy_scalar_function(&function);
+    duckdb_destroy_scalar_function(&function);
     return state;
 }
 

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -45,24 +45,23 @@ void AppendToPrefix(duckdb_function_info info, duckdb_data_chunk input, duckdb_v
 }
 
 duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection) {
-    return DuckDBSuccess;
-//    duckdb_scalar_function function = duckdb_create_scalar_function();
-//    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
-//
-//    char *prefix = (char *)malloc(8 * sizeof(char));
-//    strcpy(prefix, "prefix_");
-//
-//    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-//    duckdb_scalar_function_add_parameter(function, type);
-//    duckdb_scalar_function_set_return_type(function, type);
-//    duckdb_destroy_logical_type(&type);
-//
-//    duckdb_scalar_function_set_function(function, AppendToPrefix);
-//    duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
-//
-//    duckdb_state state = duckdb_register_scalar_function(connection, function);
-//    duckdb_destroy_scalar_function(&function);
-//    return state;
+    duckdb_scalar_function function = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(function, "capi_extra_info_scalar_function");
+
+    char *prefix = (char *)malloc(8 * sizeof(char));
+    strcpy(prefix, "prefix_");
+
+    duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    duckdb_scalar_function_add_parameter(function, type);
+    duckdb_scalar_function_set_return_type(function, type);
+    duckdb_destroy_logical_type(&type);
+
+    duckdb_scalar_function_set_function(function, AppendToPrefix);
+    duckdb_scalar_function_set_extra_info(function, (duckdb_function_info)prefix, free);
+
+    duckdb_state state = duckdb_register_scalar_function(connection, function);
+    duckdb_destroy_scalar_function(&function);
+    return state;
 }
 
 void VariadicAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {

--- a/src/functions/query_scalar_functions.c
+++ b/src/functions/query_scalar_functions.c
@@ -161,24 +161,23 @@ void CountNULL(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector
 }
 
 duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection) {
-    return DuckDBSuccess;
-//    duckdb_scalar_function function = duckdb_create_scalar_function();
-//    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
-//
-//    duckdb_logical_type any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
-//    duckdb_scalar_function_set_varargs(function, any_type);
-//    duckdb_destroy_logical_type(&any_type);
-//
-//    duckdb_scalar_function_set_special_handling(function);
-//    duckdb_scalar_function_set_volatile(function);
-//
-//    duckdb_logical_type return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
-//    duckdb_scalar_function_set_return_type(function, return_type);
-//    duckdb_destroy_logical_type(&return_type);
-//
-//    duckdb_scalar_function_set_function(function, CountNULL);
-//
-//    duckdb_state state = duckdb_register_scalar_function(connection, function);
-//    duckdb_destroy_scalar_function(&function);
-//    return state;
+    duckdb_scalar_function function = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(function, "capi_variadic_any_scalar_function");
+
+    duckdb_logical_type any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
+    duckdb_scalar_function_set_varargs(function, any_type);
+    duckdb_destroy_logical_type(&any_type);
+
+    duckdb_scalar_function_set_special_handling(function);
+    duckdb_scalar_function_set_volatile(function);
+
+    duckdb_logical_type return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
+    duckdb_scalar_function_set_return_type(function, return_type);
+    duckdb_destroy_logical_type(&return_type);
+
+    duckdb_scalar_function_set_function(function, CountNULL);
+
+    duckdb_state state = duckdb_register_scalar_function(connection, function);
+    duckdb_destroy_scalar_function(&function);
+    return state;
 }

--- a/src/functions/scalar/CMakeLists.txt
+++ b/src/functions/scalar/CMakeLists.txt
@@ -1,9 +1,0 @@
-add_library(
-        scalar_functions
-        OBJECT
-        query_library_version.c
-)
-
-set(ALL_OBJECT_FILES
-        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:scalar_functions>
-        PARENT_SCOPE)

--- a/src/include/functions/query_library_version.h
+++ b/src/include/functions/query_library_version.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "duckdb_extension.h"
+
+duckdb_state RegisterLibraryVersionFunction(duckdb_connection connection);

--- a/src/include/functions/query_scalar_functions.h
+++ b/src/include/functions/query_scalar_functions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "duckdb_extension.h"
+
+duckdb_state RegisterExtraInfoScalarFunction(duckdb_connection connection);
+duckdb_state RegisterScalarFunctionSetFunction(duckdb_connection connection);
+duckdb_state RegisterVariadicAnyScalarFunction(duckdb_connection connection);

--- a/src/include/functions/scalar/query_library_function.h
+++ b/src/include/functions/scalar/query_library_function.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include "duckdb_extension.h"
-
-void RegisterLibraryVersionFunction(duckdb_connection connection);

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,23 @@
 #include "duckdb_extension.h"
 
-#include "functions/scalar/query_library_function.h"
+#include "functions/query_library_version.h"
+#include "functions/query_scalar_functions.h"
 
 DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection, duckdb_extension_info info, struct duckdb_extension_access *access) {
-	RegisterLibraryVersionFunction(connection);
+    if (RegisterLibraryVersionFunction(connection) != DuckDBSuccess) {
+        return false;
+    }
 
+    if (RegisterExtraInfoScalarFunction(connection) != DuckDBSuccess) {
+        return false;
+    }
+    if (RegisterScalarFunctionSetFunction(connection) != DuckDBSuccess) {
+        return false;
+    }
+    if (RegisterVariadicAnyScalarFunction(connection) != DuckDBSuccess) {
+        return false;
+    }
 
-	// Return true to indicate succesful initialization
+	// Return true to indicate successful initialization.
 	return true;
 }

--- a/test/sql/library_version.test
+++ b/test/sql/library_version.test
@@ -1,21 +1,23 @@
 # name: test/sql/library_version.test
-# description: Test the capi_test_duckdb_library_version function
+# description: Test the C API duckdb_library_version function
 # group: [extensions]
 
 require reference_extension_c
 
+# RegisterLibraryVersionFunction
+
 query I nosort single_version
-SELECT library_version as v from pragma_version();
+SELECT library_version AS v FROM pragma_version();
 ----
 
 query I nosort single_version
-SELECT capi_test_duckdb_library_version() as v;
+SELECT capi_duckdb_library_version() AS v;
 ----
 
 query I nosort many_version
-SELECT library_version as v from pragma_version(), range(0,5000);
+SELECT library_version AS v FROM pragma_version(), range(0, 3000);
 ----
 
 query I nosort many_version
-SELECT capi_test_duckdb_library_version() as v FROM range(0,5000);
+SELECT capi_duckdb_library_version() AS v FROM range(0, 3000);
 ----

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -23,15 +23,15 @@ require reference_extension_c
 #----
 #84
 #126
-#
-## RegisterVariadicAnyScalarFunction
-#
-#query I
-#SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);
-#----
-#2
-#
-#statement error
-#SELECT capi_variadic_any_scalar_function();
-#----
-#Invalid Input Error: please provide at least one input parameter
+
+# RegisterVariadicAnyScalarFunction
+
+query I
+SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);
+----
+2
+
+statement error
+SELECT capi_variadic_any_scalar_function();
+----
+Invalid Input Error: please provide at least one input parameter

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -4,34 +4,52 @@
 
 require reference_extension_c
 
+## RegisterExtraInfoScalarFunction
+#
+#query I
+#SELECT capi_extra_info_scalar_function('hello');
+#----
+#prefix_hello
+#
+#query I
+#SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
+#----
+#900
+#
+## RegisterScalarFunctionSetFunction
+#
+#query II
+#SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
+#----
+#84
+#126
+#
+## RegisterVariadicAnyScalarFunction
+#
+#query I
+#SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);
+#----
+#2
+#
+#statement error
+#SELECT capi_variadic_any_scalar_function();
+#----
+#Invalid Input Error: please provide at least one input parameter
+
 # RegisterExtraInfoScalarFunction
 
-query I
+statement ok
 SELECT capi_extra_info_scalar_function('hello');
-----
-prefix_hello
 
-query I
+statement ok
 SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
-----
-900
 
 # RegisterScalarFunctionSetFunction
 
-query II
+statement ok
 SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
-----
-84
-126
 
 # RegisterVariadicAnyScalarFunction
 
-query I
+statement ok
 SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);
-----
-2
-
-statement error
-SELECT capi_variadic_any_scalar_function();
-----
-Invalid Input Error: please provide at least one input parameter

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -12,14 +12,9 @@ SELECT capi_extra_info_scalar_function('hello');
 extra_info
 
 query I
-SELECT capi_extra_info_scalar_function('hello I am not indxvdsfgdsfgdsfgfdsgfdlined');
+SELECT capi_extra_info_scalar_function('hello I am not inlined');
 ----
 extra
-
-#query I
-#SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
-#----
-#900
 
 # RegisterScalarFunctionSetFunction
 

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -4,13 +4,11 @@
 
 require reference_extension_c
 
-## RegisterExtraInfoScalarFunction
-#
-#query I
-#SELECT capi_extra_info_scalar_function('hello');
-#----
-#prefix_hello
-#
+# RegisterExtraInfoScalarFunction
+
+statement ok
+SELECT capi_extra_info_scalar_function('hello');
+
 #query I
 #SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
 #----

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -35,21 +35,3 @@ require reference_extension_c
 #SELECT capi_variadic_any_scalar_function();
 #----
 #Invalid Input Error: please provide at least one input parameter
-
-# RegisterExtraInfoScalarFunction
-
-statement ok
-SELECT capi_extra_info_scalar_function('hello');
-
-statement ok
-SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
-
-# RegisterScalarFunctionSetFunction
-
-statement ok
-SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
-
-# RegisterVariadicAnyScalarFunction
-
-statement ok
-SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -6,8 +6,10 @@ require reference_extension_c
 
 # RegisterExtraInfoScalarFunction
 
-statement ok
+query I
 SELECT capi_extra_info_scalar_function('hello');
+----
+extra_info
 
 #query I
 #SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -1,0 +1,37 @@
+# name: test/sql/scalar_functions.test
+# description: Test the C API scalar function functions
+# group: [extensions]
+
+require reference_extension_c
+
+# RegisterExtraInfoScalarFunction
+
+query I
+SELECT capi_extra_info_scalar_function('hello');
+----
+prefix_hello
+
+query I
+SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
+----
+900
+
+# RegisterScalarFunctionSetFunction
+
+query II
+SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
+----
+84
+126
+
+# RegisterVariadicAnyScalarFunction
+
+query I
+SELECT capi_variadic_any_scalar_function(NULL, 42, [1, 2, 3], NULL);
+----
+2
+
+statement error
+SELECT capi_variadic_any_scalar_function();
+----
+Invalid Input Error: please provide at least one input parameter

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -15,14 +15,14 @@ require reference_extension_c
 #SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
 #----
 #900
-#
-## RegisterScalarFunctionSetFunction
-#
-#query II
-#SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
-#----
-#84
-#126
+
+# RegisterScalarFunctionSetFunction
+
+query II
+SELECT variadic_addition_set(42, 42), variadic_addition_set(42, 42, 42);
+----
+84
+126
 
 # RegisterVariadicAnyScalarFunction
 

--- a/test/sql/scalar_functions.test
+++ b/test/sql/scalar_functions.test
@@ -11,6 +11,11 @@ SELECT capi_extra_info_scalar_function('hello');
 ----
 extra_info
 
+query I
+SELECT capi_extra_info_scalar_function('hello I am not indxvdsfgdsfgdsfgfdsgfdlined');
+----
+extra
+
 #query I
 #SELECT COUNT(1) FROM range(0, 5000) WHERE len(capi_extra_info_scalar_function(range::VARCHAR)) = 10;
 #----


### PR DESCRIPTION
This PR covers all `...[scalar]...` functions in the C API. 
It also includes:
- some minor folder reorganization.
- slightly less verbose function names for the tests.
- `duckdb_state` returns state when registering the various scalar functions (still a big ugly...).

The following would help with building this reference extension.
- [ ] Python script to get the diff between the covered functions and the extension function struct. These are the functions that still need to be covered.
- [ ] A formatter.

I'll also throw the command to get some debugging going in here.
```
lldb ./configure/venv/bin/python3 -- -m duckdb_sqllogictest --test-dir test/sql  --external-extension build/debug/reference_extension_c.duckdb_extension
```